### PR TITLE
add mysql setting

### DIFF
--- a/DjangoTutorial/settings.py
+++ b/DjangoTutorial/settings.py
@@ -10,7 +10,11 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+import environ
 from pathlib import Path
+
+env = environ.Env()
+env.read_env('.env')
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -75,8 +79,12 @@ WSGI_APPLICATION = 'DjangoTutorial.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': env('DB_NAME'),
+        'USER': env('DB_USERNAME'),
+        'PASSWORD': env('DB_PASSWORD'),
+        'HOST': env('DB_HOST'),
+        'PORT': env('DB_PORT'),
     }
 }
 


### PR DESCRIPTION
add mysql setting

# before running server
1. create `.env` file at project root directory.
2. add the following variables in `.env` file

```
DB_NAME
DB_USERNAME
DB_PASSWORD
DB_HOST
DB_PORT
``` 

3. install mysqlclient : run `pip install mysqlclient==2.1.1`
    -  latest version cannot install at macOS Sonoma
4. install django-environ : run `pip install django-environ`